### PR TITLE
[CFE-435] Update starwidth value for consistency

### DIFF
--- a/app/assets/stylesheets/sephora_style_guide/partials/_product_card.scss
+++ b/app/assets/stylesheets/sephora_style_guide/partials/_product_card.scss
@@ -17,16 +17,18 @@
 
 .rating-container {
   .rateit .rateit-range {
-    background: asset-url('sephora_style_guide/star.png') !important;
-    background-size: 15px 12px !important;
+    background: asset-url('sephora_style_guide/star.png');
+    background-size: 15px 12px;
+    background-repeat: repeat-x;
   }
 
   .rateit .rateit-selected,
   .rateit .rateit-preset {
     position: absolute;
     top: 0;
-    background: asset-url('sephora_style_guide/star-filled.png') !important;
-    background-size: 15px 12px !important;
+    background: asset-url('sephora_style_guide/star-filled.png');
+    background-size: 15px 12px;
+    background-repeat: repeat-x;
   }
 }
 

--- a/app/views/sephora_style_guide/home/_product_card.slim
+++ b/app/views/sephora_style_guide/home/_product_card.slim
@@ -53,7 +53,7 @@ article#product-card
               p.product-card-product Chubby Stick Moisturizing Lip Colour Balm
               p.product-price $26.00
               .product-card-rating.rating-container
-                .rateit data-rateit-resetable='false' data-rateit-readonly='true' data-rateit-starwidth='14.7' data-rateit-starheight='12' data-rateit-value='1' data-rateit-ispreset='true'
+                .rateit data-rateit-resetable='false' data-rateit-readonly='true' data-rateit-starwidth='14.65' data-rateit-starheight='12' data-rateit-value='1' data-rateit-ispreset='true'
               .product-card-variants-count 13 shades
 
         .col-6.col-md-3
@@ -76,7 +76,7 @@ article#product-card
                 span.product-price-sale-new $127.00
                 span.product-price-sale-text= '(50%)'
               .product-card-rating.rating-container
-                .rateit data-rateit-resetable='false' data-rateit-readonly='true' data-rateit-starwidth='14.7' data-rateit-starheight='12' data-rateit-value='5' data-rateit-ispreset='true'
+                .rateit data-rateit-resetable='false' data-rateit-readonly='true' data-rateit-starwidth='14.65' data-rateit-starheight='12' data-rateit-value='5' data-rateit-ispreset='true'
 
         .col-6.col-md-3
           .product-card name='product3' @mouseover='mouseoverProductCard' @mouseleave='mouseleaveProductCard'
@@ -101,5 +101,5 @@ article#product-card
                 span.product-price-sale-new $26.00
                 span.product-price-sale-text= '(50%)'
               .product-card-rating.rating-container
-                .rateit data-rateit-resetable='false' data-rateit-readonly='true' data-rateit-starwidth='14.7' data-rateit-starheight='12' data-rateit-value='3.5' data-rateit-ispreset='true'
+                .rateit data-rateit-resetable='false' data-rateit-readonly='true' data-rateit-starwidth='14.65' data-rateit-starheight='12' data-rateit-value='3.5' data-rateit-ispreset='true'
               .product-card-variants-count 2 sizes


### PR DESCRIPTION
- Update starwidth value to 14.65 for product card demo

- Enable repeat for star background on the horizontal axis only to prevent issues with tips of stars displaying when display is scaled

- Remove !important tags for stars as they are not necessary