### PR TITLE
[CFE-438] Fix product rating stars display when display is scaled

### DIFF
--- a/app/assets/stylesheets/sephora_style_guide/partials/_product_card.scss
+++ b/app/assets/stylesheets/sephora_style_guide/partials/_product_card.scss
@@ -17,16 +17,18 @@
 
 .rating-container {
   .rateit .rateit-range {
-    background: asset-url('sephora_style_guide/star.png') !important;
-    background-size: 15px 12px !important;
+    background: asset-url('sephora_style_guide/star.png');
+    background-size: 15px 12px;
+    background-repeat: repeat-x;
   }
 
   .rateit .rateit-selected,
   .rateit .rateit-preset {
     position: absolute;
     top: 0;
-    background: asset-url('sephora_style_guide/star-filled.png') !important;
-    background-size: 15px 12px !important;
+    background: asset-url('sephora_style_guide/star-filled.png');
+    background-size: 15px 12px;
+    background-repeat: repeat-x;
   }
 }
 


### PR DESCRIPTION
- Enable repeat for star background on the horizontal axis only to prevent issues with tips of stars displaying when display is scaled

- Remove `!important` tags for stars as they are not necessary

Deployed to https://staging-unagi.luxola.com/